### PR TITLE
Use pure empty object as storage, to prevent key conflicts

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -141,4 +141,16 @@ describe('storage', () =>
       expect(storage.toString()).toEqual('[object Storage]');
       expect(storage.toString).toHaveBeenCalledTimes(1);
     });
+
+    test('iteration', () => {
+      storage.setItem('key1', 'value1');
+      storage.setItem('key2', 'value2');
+      storage.setItem('key3', 'value3');
+
+      expect(Object.entries(storage)).toEqual([
+        ['key1', 'value1'],
+        ['key2', 'value2'],
+        ['key3', 'value3'],
+      ]);
+    });
   }));

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -56,7 +56,8 @@ describe('storage', () =>
       const KEY = 'foo',
         VALUE1 = 'bar',
         VALUE2 = 'baz',
-        DOES_NOT_EXIST = 'does not exist';
+        DOES_NOT_EXIST = 'does not exist',
+        LOCAL_STORAGE_PROPERTY_NAME = 'key';
 
       storage.setItem(KEY, VALUE1);
       expect(storage.getItem(KEY)).toBe(VALUE1);
@@ -68,6 +69,14 @@ describe('storage', () =>
 
       expect(storage.getItem(DOES_NOT_EXIST)).toBeNull();
       expect(storage.getItem).toHaveBeenLastCalledWith(DOES_NOT_EXIST);
+
+      expect(() =>
+        storage.setItem(LOCAL_STORAGE_PROPERTY_NAME, VALUE1)
+      ).not.toThrow();
+      expect(storage.getItem(LOCAL_STORAGE_PROPERTY_NAME)).toBe(VALUE1);
+      expect(storage.getItem).toHaveBeenLastCalledWith(
+        LOCAL_STORAGE_PROPERTY_NAME
+      );
     });
 
     // removeItem

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -1,26 +1,30 @@
 export class LocalStorage {
   constructor(jest) {
+    Object.defineProperty(this, 'store', {
+      enumerable: false,
+      value: {},
+    });
     Object.defineProperty(this, 'getItem', {
       enumerable: false,
-      value: jest.fn(key => this[key] || null),
+      value: jest.fn(key => this.store[key] || null),
     });
     Object.defineProperty(this, 'setItem', {
       enumerable: false,
       // not mentioned in the spec, but we must always coerce to a string
       value: jest.fn((key, val = '') => {
-        this[key] = val + '';
+        this.store[key] = val + '';
       }),
     });
     Object.defineProperty(this, 'removeItem', {
       enumerable: false,
       value: jest.fn(key => {
-        delete this[key];
+        delete this.store[key];
       }),
     });
     Object.defineProperty(this, 'clear', {
       enumerable: false,
       value: jest.fn(() => {
-        Object.keys(this).map(key => delete this[key]);
+        Object.keys(this.store).map(key => delete this.store[key]);
       }),
     });
     Object.defineProperty(this, 'toString', {
@@ -31,15 +35,15 @@ export class LocalStorage {
     });
     Object.defineProperty(this, 'key', {
       enumerable: false,
-      value: jest.fn(idx => Object.keys(this)[idx] || null),
+      value: jest.fn(idx => Object.keys(this.store)[idx] || null),
     });
   } // end constructor
 
   get length() {
-    return Object.keys(this).length;
+    return Object.keys(this.store).length;
   }
   // for backwards compatibility
   get __STORE__() {
-    return this;
+    return this.store;
   }
 }


### PR DESCRIPTION
For now, it is not possible to write `localStorage.getItem(key)` when `key` is equal to `'key'`, `'clear'`, ... because those keys have the same name than some of `LocalStorage` mock properties.

I added a failing test (because I didn't fixed it yet) which gives me this error `TypeError: Cannot assign to read only property 'key' of object '[object Object]'`.
