### PR TITLE
Document mock error

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,5 +177,50 @@ test('should not be impacted by the previous test', () => {
 });
 ```
 
+If needing to change the mock implementation of `localStorage` methods, please use jest's
+[mockImplementationOnce](https://jestjs.io/docs/en/mock-function-api#mockfnmockimplementationoncefn).
+Using other methods may result in the current method mock being permanently overwritten.
+
+```js
+// does NOT work
+test('should override the setItem mock and reset it to its previous implementation', () => {
+  const KEY = 'foo',
+    VALUE = 'bar';
+
+  localStorage.setItem.mockImplementation(() => {
+    throw 'Something went wrong!'
+  })
+  expect(() => {
+    localStorage.setItem(KEY, VALUE)
+  }).toThrow('Something went wrong!')
+
+  localStorage.setItem.mockClear();
+  expect(() => {
+    localStorage.setItem(KEY, VALUE)
+  }).not.toThrow('Something went wrong!')
+});
+
+// does work
+test('should override the setItem mock and reset it to its previous implementation', () => {
+  const KEY = 'foo',
+    VALUE = 'bar';
+  
+  localStorage.setItem.mockImplementationOnce(() => {
+    throw 'Something went wrong!'
+  })
+  expect(() => {
+    localStorage.setItem(KEY, VALUE)
+  }).toThrow('Something went wrong!')
+  
+  localStorage.setItem.mockClear();
+  expect(() => {
+    localStorage.setItem(KEY, VALUE)
+  }).not.toThrow('Something went wrong!')
+
+  expect(localStorage.getItem(KEY)).toEqual(VALUE)
+});
+
+```
+
 See the [contributing guide](./CONTRIBUTING.md) for details on how you can
 contribute.

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,5 +1,5 @@
 describe('storage', () =>
-  [localStorage, sessionStorage].map(storage => {
+  [localStorage, sessionStorage].map((storage) => {
     // https://html.spec.whatwg.org/multipage/webstorage.html#storage
     beforeEach(() => {
       storage.clear();

--- a/__tests__/setup.test.js
+++ b/__tests__/setup.test.js
@@ -1,5 +1,3 @@
-import { LocalStorage } from '../src/localstorage';
-
 describe('setup', () => {
   const orignalImpGlobals = {};
 

--- a/__tests__/setup.test.js
+++ b/__tests__/setup.test.js
@@ -1,29 +1,29 @@
 import { LocalStorage } from '../src/localstorage';
 
 describe('setup', () => {
-  const orignalImpGlobsl = {};
+  const orignalImpGlobals = {};
 
-  const setupGloabls = (restore = false) => {
+  const setupGlobals = (restore = false) => {
     [
       '_localStorage',
       'localStorage',
       '_sessionStorage',
       'sessionStorage',
-    ].forEach(globalKey => {
+    ].forEach((globalKey) => {
       if (restore) {
         delete global[globalKey];
-        global[globalKey] = orignalImpGlobsl[globalKey];
+        global[globalKey] = orignalImpGlobals[globalKey];
       } else {
-        orignalImpGlobsl[globalKey] = global[globalKey];
+        orignalImpGlobals[globalKey] = global[globalKey];
         delete global[globalKey];
       }
     });
   };
 
-  const restoreGlobals = () => setupGloabls(true);
+  const restoreGlobals = () => setupGlobals(true);
 
   beforeEach(() => {
-    setupGloabls();
+    setupGlobals();
     jest.resetModuleRegistry();
   });
 
@@ -31,7 +31,7 @@ describe('setup', () => {
     restoreGlobals();
   });
 
-  ['_localStorage', '_sessionStorage'].forEach(gKey => {
+  ['_localStorage', '_sessionStorage'].forEach((gKey) => {
     it(`[${gKey}] should define a property on the global object with writable false`, () => {
       require('../src/setup');
       expect(global[gKey.replace('_', '')].constructor.name).toBe(

--- a/src/localstorage.js
+++ b/src/localstorage.js
@@ -2,7 +2,7 @@ export class LocalStorage {
   constructor(jest) {
     Object.defineProperty(this, 'getItem', {
       enumerable: false,
-      value: jest.fn(key => this[key] || null),
+      value: jest.fn((key) => this[key] || null),
     });
     Object.defineProperty(this, 'setItem', {
       enumerable: false,
@@ -13,14 +13,14 @@ export class LocalStorage {
     });
     Object.defineProperty(this, 'removeItem', {
       enumerable: false,
-      value: jest.fn(key => {
+      value: jest.fn((key) => {
         delete this[key];
       }),
     });
     Object.defineProperty(this, 'clear', {
       enumerable: false,
       value: jest.fn(() => {
-        Object.keys(this).map(key => delete this[key]);
+        Object.keys(this).map((key) => delete this[key]);
       }),
     });
     Object.defineProperty(this, 'toString', {
@@ -31,7 +31,7 @@ export class LocalStorage {
     });
     Object.defineProperty(this, 'key', {
       enumerable: false,
-      value: jest.fn(idx => Object.keys(this)[idx] || null),
+      value: jest.fn((idx) => Object.keys(this)[idx] || null),
     });
   } // end constructor
 


### PR DESCRIPTION
Hey @clarkbw,

A few peers of mine recently ran into some issues with understanding how to properly override the storage mocks within this library.  `mockImplementation` leads to the mock being completely overwritten and persisting through `mockClear` calls. Though this might be clear to a lot of developers familiar with `Jest`, the behavior under the hood might not be as clear to those less familiar. We can leverage edge case mock overrides with `mockImplementationOnce` in our case due to how jest handles `specificMockImpls` under the hood [here](https://github.com/facebook/jest/blob/master/packages/jest-mock/src/index.ts).

I have added some documentation to the README in 477a7e8ee21172f74c23d835524c7d8bed411a15 to help guide users in the right direction so the options to override the mock in edge cases are clearly understood.

While I was in there, I fixed a few small spelling errors and ran the linter. I hope that is OK! :smile: 

Let me know what you think when you can and thanks in advance for taking a look at this.