### PR TITLE
Update README.md bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,15 @@ Reset your `localStorage` data and mocks before each test to prevent leaking.
 
 ```js
 beforeEach(() => {
-  // values stored in tests will also be available in other tests unless you run
+  // to fully reset the state between tests, clear the storage
   localStorage.clear();
-  // or directly reset the storage
-  localStorage.__STORE__ = {};
-  // you could also reset all mocks, but this could impact your other mocks
-  jest.resetAllMocks();
-  // or individually reset a mock used
+  // and reset all mocks
+  jest.clearAllMocks();
+  
+  // clearAllMocks will impact your other mocks too, so you can optionally reset individual mocks instead:
   localStorage.setItem.mockClear();
+  // you can also directly reset the storage (same as .clear above)
+  localStorage.__STORE__ = {};
 });
 
 test('should not impact the next test', () => {


### PR DESCRIPTION
The current readme suggests using resetAllMocks between tests, but this actually breaks the mocks. The soltion is to use clearAllMocks which is already used within this project's own tests. I've updated the readme to suggest the correct function, and also make it more clear that `.clear()` also needs to be used to fully reset state between tests.

Original bug report: https://github.com/clarkbw/jest-localstorage-mock/issues/83