### PR TITLE
remove clear example from README.md (would throw an error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ beforeEach(() => {
   
   // clearAllMocks will impact your other mocks too, so you can optionally reset individual mocks instead:
   localStorage.setItem.mockClear();
-  // you can also directly reset the storage (same as .clear above)
-  localStorage.__STORE__ = {};
 });
 
 test('should not impact the next test', () => {


### PR DESCRIPTION
This PR removes a misleading example from README.md, which would fail with `TypeError: Cannot set property __STORE__ of #<LocalStorage> which has only a getter` anyway.
That this example is a pitfall was already pointed out in #90 and I just fell for it too when trying `jest-localstorage-mock` for the first time.